### PR TITLE
Update baseimage to ubuntu 20.04

### DIFF
--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 LABEL maintainer="Eugen Ciur <eugen@papermerge.com>"
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get install -y \

--- a/docker/worker.dockerfile
+++ b/docker/worker.dockerfile
@@ -1,6 +1,8 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
 LABEL maintainer="Eugen Ciur <eugen@papermerge.com>"
+
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get install -y \


### PR DESCRIPTION
Um die docker Images auf Systemen mit arm64 nutzen zu können habe ich das Basisimage auf ubuntu 20.04 aktualisiert.

English:
To use the docker images on systems with arm64 I have updated the base image to ubuntu 20.04.