### PR TITLE
worker docker config also uses env variables

### DIFF
--- a/docker/1.4/config/worker.production.py
+++ b/docker/1.4/config/worker.production.py
@@ -1,3 +1,5 @@
+import os
+
 from .base import *  # noqa
 
 DEBUG = False
@@ -12,11 +14,11 @@ ALLOWED_HOSTS = ['*']
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'dbname',
-        'USER': 'dbuser',
-        'PASSWORD': 'dbpass',
-        'HOST': 'db',
-        'PORT': 5432,
+        'NAME': os.environ.get('POSTGRES_DB', 'dbname'),
+        'USER': os.environ.get('POSTGRES_USER', 'dbuser'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'dbpass'),
+        'HOST': os.environ.get('POSTGRES_HOST', 'db'),
+        'PORT': os.environ.get('POSTGRES_PORT', 5432),
     },
 }
 


### PR DESCRIPTION
### Description
Fixes #114, this sets the docker worker config to also use environment variables like the app config already does.

### Test Plan
[x] `cd docker/1.4 && docker-compose up` - ensure that the defaults still yield a functional instance
[x] `cd docker/1.4 && docker build -t papermerge-worker:dev -f worker.dockerfile` - deploy compiled image to a running nomad cluster and ensure it picks up appropriate environment variables.