### PR TITLE
Add MySQL support

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -271,6 +271,8 @@ elif cfg_papermerge.get("DBTYPE", False) == "mysql":
     DATABASES["default"]["PASSWORD"] = cfg_papermerge.get("DBPASS", "")
     DATABASES["default"]["HOST"] = cfg_papermerge.get("DBHOST", "localhost")
     DATABASES["default"]["PORT"] = cfg_papermerge.get("DBPORT", 3306)
+    # Requires MySQL > 5.7.7 or innodb_large_prefix set to on
+    SILENCED_SYSTEM_CHECKS = ['mysql.E001']
 
 FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.TemporaryFileUploadHandler'

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -253,16 +253,24 @@ DATABASES = {
     }
 }
 
-if cfg_papermerge.get("DBUSER", False):
+if cfg_papermerge.get("DBTYPE", False) == "postgresql":
     DATABASES["default"] = {
         "ENGINE": "django.db.backends.postgresql_psycopg2",
         "NAME": cfg_papermerge.get("DBNAME", "papermerge"),
-        "USER": cfg_papermerge.get("DBUSER"),
+        "USER": cfg_papermerge.get("DBUSER", "papermerge"),
     }
     DATABASES["default"]["PASSWORD"] = cfg_papermerge.get("DBPASS", "")
     DATABASES["default"]["HOST"] = cfg_papermerge.get("DBHOST", "localhost")
     DATABASES["default"]["PORT"] = cfg_papermerge.get("DBPORT", 5432)
-
+elif cfg_papermerge.get("DBTYPE", False) == "mysql":
+    DATABASES["default"] = {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": cfg_papermerge.get("DBNAME", "papermerge"),
+        "USER": cfg_papermerge.get("DBUSER", "papermerge"),
+    }
+    DATABASES["default"]["PASSWORD"] = cfg_papermerge.get("DBPASS", "")
+    DATABASES["default"]["HOST"] = cfg_papermerge.get("DBHOST", "localhost")
+    DATABASES["default"]["PORT"] = cfg_papermerge.get("DBPORT", 3306)
 
 FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.TemporaryFileUploadHandler'

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -210,7 +210,20 @@ Database
 ###########
 
 By default, Papermerge uses SQLite3 database (which is a file located in :ref:`db_dir`). Alternatively
-you can use PostgreSQL database. Following are options for PostgreSQL database connections.
+you can use a PostgreSQL or MySQL database. Following are options for PostgreSQL and MySQL database connections.
+
+ .. _dbtype:
+
+``DBTYPE``
+~~~~~~~~~~~
+
+context: ``main app``
+
+DB type (if different from SQLITE3). Can be either "postgresql" for PostgreSQL or "mysql" for MySQL/MariaDB.
+
+  Example:
+
+    DBTYPE = "mysql"
 
  .. _dbuser:
 
@@ -219,8 +232,7 @@ you can use PostgreSQL database. Following are options for PostgreSQL database c
 
 context: ``main app``
 
-DB user used for PostgreSQL database connection. If specified will automatically 'switch' from
-sqlite3 to PostgreSQL database.
+DB user used for database connection.
 
   Example:
 
@@ -233,7 +245,7 @@ sqlite3 to PostgreSQL database.
 
 context: ``main app``
 
-PostgreSQL database name.
+Database name.
 Default value is papermerge.
 
 .. _dbhost:
@@ -243,7 +255,7 @@ Default value is papermerge.
 
 context: ``main app``
  
-PostgreSQL database host.
+Database host.
 Default value is localhost.
 
 .. _dbport:
@@ -253,13 +265,13 @@ Default value is localhost.
 
 context: ``main app``
    
-PostgreSQL database port. Port must be specified as integer number. No string quotes.
+Database port. Port must be specified as integer number. No string quotes.
 
   Example:
 
     DBPORT = 5432
 
-Default value is 5432.
+Default value is 5432 for PostgreSQL and 3306 for MySQL.
 
 .. _dbpass:
 
@@ -268,7 +280,7 @@ Default value is 5432.
 
 context: ``main app``
  
-Password for connecting to PostgreSQL database
+Password for connecting to database
 Default value is empty string.
 
 .. _settings_email:

--- a/requirements/extra.txt
+++ b/requirements/extra.txt
@@ -1,2 +1,3 @@
 psycopg2-binary
 celery[redis]
+mysqlclient


### PR DESCRIPTION
Added new variable DBTYPE to choose MySQL or PostgreSQL. Due to fields possibly longer than 255 chars MySQL 5.7.7 (or innodb_large_prefix on older versions) is required.
**This is not working yet.**
What is working:
- [x] Possible to choose backend from settings (DBTYPE)
- [x] Documentation updated
- [ ] Right now migration aren't working, in particular 0001_initial and 0005_auto_20200419_0639 since they require PostgreSQL fulltext search (django.contrib.postgres.search.SearchVectorField)

Input from the author is necessary to decide how to rewrite the migrations, since fulltext search is not supported on MySQL.