### PR TITLE
Digest size and validation

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -275,8 +275,6 @@ elif cfg_papermerge.get("DBTYPE", False) in (
     DATABASES["default"]["PASSWORD"] = cfg_papermerge.get("DBPASS", "")
     DATABASES["default"]["HOST"] = cfg_papermerge.get("DBHOST", "localhost")
     DATABASES["default"]["PORT"] = cfg_papermerge.get("DBPORT", 3306)
-    # Requires MySQL > 5.7.7 or innodb_large_prefix set to on
-    SILENCED_SYSTEM_CHECKS = ['mysql.E001']
 
 FILE_UPLOAD_HANDLERS = [
     'django.core.files.uploadhandler.TemporaryFileUploadHandler'

--- a/papermerge/core/migrations/0001_initial.py
+++ b/papermerge/core/migrations/0001_initial.py
@@ -79,7 +79,7 @@ class Migration(migrations.Migration):
                 ('file_name', models.CharField(default='', max_length=1024)),
                 ('notes', models.TextField(blank=True, null=True, verbose_name='Notes')),
                 ('size', models.BigIntegerField(help_text='Size of file_orig attached. Size is in Bytes')),
-                ('digest', models.CharField(blank=True, help_text='Digest of file_orig attached. Size is in Bytes.It is used to figure out if file was already processed.', max_length=512, null=True, unique=True)),
+                ('digest', models.CharField(blank=True, help_text='Digest of file_orig attached. Size is in Bytes.It is used to figure out if file was already processed.', max_length=70, null=True)),
                 ('page_count', models.IntegerField(default=1)),
                 ('text', models.TextField()),
                 ('celery_task_id', models.UUIDField(blank=True, default=None, null=True)),

--- a/papermerge/core/models/document.py
+++ b/papermerge/core/models/document.py
@@ -644,6 +644,7 @@ class Document(BaseTreeNode):
         """
         check if user already uploaded this file
         """
-        same_documents = Document.objects.filter(digest=self.digest)
-        if same_documents.filter(user=self.user).exists():
-            raise ValidationError("{} already has this document".format(self.user))
+        if self.digest:
+            same_documents = Document.objects.filter(digest=self.digest)
+            if same_documents.filter(user=self.user).exists():
+                raise ValidationError("{} already has this document".format(self.user))

--- a/papermerge/core/views/documents.py
+++ b/papermerge/core/views/documents.py
@@ -383,7 +383,7 @@ def upload(request):
         return msg, status
 
     logger.debug("creating document {}".format(f.name))
-
+    
     doc = Document.create_document(
         user=user,
         title=f.name,


### PR DESCRIPTION
Digest database size is way too big and due to uniqueness was interfering with MySQL databases without innodb_large_prefix on. Now model performs correct validation of user+digest and MySQL constraints can be removed.
The digest is actually not generated though. It would probably be a good idea to user DocumentImporter also in the upload view and put the logic there.

Also I would have changed a few of the lengths in the model fields (1024 character file name? seems a bit excessive...) but I left it out since this is purely a design choice.