### PR TITLE
Update papermerge-core version in base requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # https://github.com/papermerge/papermerge-core
-papermerge-core == 2.0.0rc45
+papermerge-core == 2.0.0rc38
 # https://github.com/papermerge/mglib
 mglib == 1.3.8
 mgclipboard >= 0.3.0


### PR DESCRIPTION
Fix referenced version for papermerge-core.

Reference currently specifies a release version, which does not yet exist. Most recent papermerge-core version is 2.0.0.rc38 and not 2.0.0.rc45, correct?

