### PR TITLE
docs: Do not expose media directory

### DIFF
--- a/docs/source/setup/server_configurations.rst
+++ b/docs/source/setup/server_configurations.rst
@@ -113,12 +113,7 @@ Let's say papermerge.site. Here is configuration example for virtual host::
             Require all granted
         </Directory>
 
-        Alias /media/ /var/media/papermerge/
         Alias /static/ /var/static/papermerge/
-
-        <Directory /var/media/papermerge>
-           Require all granted
-        </Directory>
 
         <Directory /var/startic/papermerge>
           Require all granted
@@ -225,10 +220,6 @@ And finally connect nginx with gunicorn. Here is a sample configuration for ngin
 
         location /static/ {
             alias /opt/static/;
-        }
-
-        location /media/ {
-            alias /opt/media/;
         }
 
         location / {


### PR DESCRIPTION
# Description

Do not instruct users to expose the media directory unprotected. This is unsafe and as far as I can tell not necessary for normal operation of a Papermerge instance.

Serving the media directory straight through the webserver circumvents all access controls present in the web frontend and the REST API, leaving user data unprotected. Anyone who gets access to a valid document link can access that document.
If the user's webserver has directory listings enabled, this turns into a complete disaster, as all files are immediately discoverable and accessible.

My only guess is, that this might have been required in previous versions of Papermerge?

## Type of change

- [x] This change requires a documentation update

# How Has This Been Tested?

n/a

# Checklist:

- [x] I have read the [Contributing file available here](https://github.com/ciur/papermerge/blob/master/CONTRIBUTING.md)
- ~I have formatted this PR according to [PEP8 rules](https://www.python.org/dev/peps/pep-0008/)~
- ~I have commented my code, particularly in hard-to-understand areas~
- ~I have made corresponding changes to the documentation~
- ~My changes generate no new warnings~
- ~I have added tests that prove my fix is effective or that my feature works~
- ~New and existing unit tests pass locally with my changes~
